### PR TITLE
Make nvm.startup multiline

### DIFF
--- a/app/nvm/map.jinja
+++ b/app/nvm/map.jinja
@@ -9,11 +9,10 @@
         'package': 'nvm',
         'installer': 'pkg.installed',
         'home': '/Users/',
-        'startup': '
+        'startup': '|
           # NVM
           export NVM_DIR=~/.nvm
-          source $(brew --prefix nvm)/nvm.sh
-        '
+          source $(brew --prefix nvm)/nvm.sh'
     },
     'Linux': {
         'package': 'nvm',

--- a/app/nvm/map.jinja
+++ b/app/nvm/map.jinja
@@ -12,7 +12,8 @@
         'startup': '|
           # NVM
           export NVM_DIR=~/.nvm
-          source $(brew --prefix nvm)/nvm.sh'
+          source $(brew --prefix nvm)/nvm.sh
+          '
     },
     'Linux': {
         'package': 'nvm',


### PR DESCRIPTION
The strings were being concatenated without newlines without the pipe character.