### PR TITLE
Switch to lookup for OS specific services

### DIFF
--- a/app/salt-minion/init.sls
+++ b/app/salt-minion/init.sls
@@ -27,8 +27,8 @@ Register the salt minion service:
 
 Enable the salt service:
   service.enabled:
-    - name: salt-minion
+    - name: {{salt.service}}
 
 Start the salt service:
   service.running:
-    - name: salt-minion
+    - name: {{salt.service}}

--- a/app/salt-minion/map.jinja
+++ b/app/salt-minion/map.jinja
@@ -2,13 +2,16 @@
     'Windows': {
         'package': 'salt',
         'installer': 'chocolatey.installed'
+        'service': 'salt-minion'
     },
     'MacOS': {
         'package': 'salt',
         'installer': 'pkg.installed'
+        'service': 'com.saltstack.salt.minion'
     },
     'Arch': {
         'package': 'salt',
         'installer': 'pkg.installed'
+        'service': 'salt-minion'
     },
 }, merge=salt['pillar.get']('salt-minion:lookup')) %}


### PR DESCRIPTION
Mac uses a different service name than other operating systems to conform to Apple's standards. Use lookups manage these by OS.