### PR TITLE
Use adoptopenjdk8 for mac

### DIFF
--- a/app/java/map.jinja
+++ b/app/java/map.jinja
@@ -4,8 +4,16 @@
         'installer': 'chocolatey.installed'
     },
     'MacOS': {
-      'package': 'homebrew/cask-versions/java8',
-      'installer': 'test.nop',
+      'package': 'homebrew/cask-versions/adoptopenjdk8',
+      'installer': {
+        'pkg.installed': [
+          {
+            'require': [
+              {'sls': 'app/magic-sudo'}
+            ]
+          }
+        ]
+      },
       'home': '$(/usr/libexec/java_home)'
     },
     'Arch': {


### PR DESCRIPTION
java8 package is dead
java package doesn't have EE modules and might require changes to builds currently targeting 8