### PR TITLE
Source .profile on Macs or brew breaks

### DIFF
--- a/os-config/mx-profile.sls
+++ b/os-config/mx-profile.sls
@@ -25,7 +25,11 @@ Ensure user profile exists:
 Ensure user is running the mx profile content:
   file.append:
     - name: {{ userinfo.home }}/{{ rcfile }}
-    - text: source ~/.mx_profile
+    - text:
+      {%- if grains.os in ('MacOS',) %}
+      - source ~/.profile
+      {% endif -%}
+      - source ~/.mx_profile
 
   {% endif %} #skip this file if we're on windows
 {%- endif %}


### PR DESCRIPTION
M1 installs to /opt/homebrew and evals in .profile
Installing a .bash_profile stops .profile from running